### PR TITLE
Calculate points based on distance to edge of polygon

### DIFF
--- a/src/MapClickHandler.jsx
+++ b/src/MapClickHandler.jsx
@@ -19,6 +19,7 @@ import {
   closePolygon,
   featureMatchesSong,
   getCenterOfPolygon,
+  getDistanceToPolygon,
 } from './utils/clickHandler-utils';
 import { toOurPixelCoordinates } from './utils/coordinate-utils';
 import getCurrentDateInBritain from './utils/getCurrentDateinBritain';
@@ -102,18 +103,12 @@ export const MapClickHandler = ({
         localStorage.setItem('dailyResults', JSON.stringify(resultsArray));
       } else {
         incrementSongFailureCount(currentSong);
-        const correctPolygonCenterPoints =
-          correctFeature.geometry.coordinates.map((polygon) =>
-            getCenterOfPolygon(polygon.map(toOurPixelCoordinates)),
-          );
-        const distances = correctPolygonCenterPoints.map((point) =>
-          calculateDistance(ourPixelCoordsClickedPoint, point),
-        );
-        const minDistance = Math.min(...distances);
-        setGuessResult(Math.round(calculatePoints(minDistance)));
-        resultsArrayTemp[dailyChallengeIndex] = Math.round(
-          calculatePoints(minDistance),
-        );
+        const distanceToPolygon = Math.min(
+            ...correctFeature.geometry.coordinates.map((polygon) =>
+                getDistanceToPolygon(ourPixelCoordsClickedPoint, polygon.map(toOurPixelCoordinates))));
+        const points = Math.round(calculatePoints(distanceToPolygon));
+        setGuessResult(points);
+        resultsArrayTemp[dailyChallengeIndex] = points;
         setResultsArray(resultsArrayTemp);
         localStorage.setItem('dailyResults', JSON.stringify(resultsArray));
       }

--- a/src/utils/clickHandler-utils.js
+++ b/src/utils/clickHandler-utils.js
@@ -30,4 +30,42 @@ const getCenterOfPolygon = (points) => {
     return [xSum / points.length, ySum / points.length];
 };
 
-export { closePolygon, featureMatchesSong, calculateDistance, getCenterOfPolygon }
+const getDistanceToPolygon = (point, polygon) => {
+    const polygonLines = polygon.map((point, i) => [point, polygon[(i + 1) % polygon.length]]);
+    const distances = polygonLines.map((line) => getDistanceToLine(point, line));
+    return Math.min(...distances);
+};
+
+const getDistanceToLine = (point, line) => {
+    let A = point[0] - line[0][0];
+    let B = point[1] - line[0][1];
+    let C = line[1][0] - line[0][0];
+    let D = line[1][1] - line[0][1];
+
+    let dot = A * C + B * D;
+    let lenSq = C * C + D * D;
+    let param = -1;
+
+    if (lenSq !== 0)  // in case of 0 length line
+        param = dot / lenSq;
+
+    let xx, yy;
+
+    if (param < 0) {
+        xx = line[0][0];
+        yy = line[0][1];
+    } else if (param > 1) {
+        xx = line[1][0];
+        yy = line[1][1];
+    } else {
+        xx = line[0][0] + param * C;
+        yy = line[0][1] + param * D;
+    }
+
+    let dx = point[0] - xx;
+    let dy = point[1] - yy;
+
+    return Math.sqrt(dx * dx + dy * dy);
+}
+
+export { closePolygon, featureMatchesSong, calculateDistance, getCenterOfPolygon, getDistanceToPolygon }


### PR DESCRIPTION
Currently, a lot of points are deducted when clicking even 1 pixel outside of the correct region. This is because points are deducted based on the distance to the center of the polygon. This problem becomes worse on larger regions, as the distance from the center to the edge of the polygon increases.

This change makes it so the error distance is calculated from the distance between the clicked point and the edge of the polygon.

Before:
![image](https://github.com/user-attachments/assets/8c732bf4-cd55-4573-968b-a62673e3140e)

After:
![image](https://github.com/user-attachments/assets/f8d72a13-7f97-4f8b-9ce0-33eb74bd10ab)
